### PR TITLE
Fix path utilities and FCM handling

### DIFF
--- a/app/src/main/java/com/kyata/pdfreader/services/MyFirebaseMessagingService.java
+++ b/app/src/main/java/com/kyata/pdfreader/services/MyFirebaseMessagingService.java
@@ -31,45 +31,52 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
-        // TODO(developer): Handle FCM messages here.
         super.onMessageReceived(remoteMessage);
         Log.d(TAG, "From: " + remoteMessage.getFrom());
 
-        // Check if message contains a data payload.
-        if (remoteMessage.getData().size() > 0) {
-            Log.d(TAG, "Message data payload: " + remoteMessage.getData());
-        }
-        // Check if message contains a notification payload.
+        String title = null;
+        String body = null;
+
         if (remoteMessage.getNotification() != null) {
-            Intent intentAct = new Intent(this, SplashActivity.class);
-            intentAct.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            int flag = 0;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                flag = PendingIntent.FLAG_IMMUTABLE;
-            }
-            Log.d(TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
-            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, "channel_id")
-                    .setContentTitle(remoteMessage.getNotification().getTitle())
-                    .setContentText(remoteMessage.getNotification().getBody())
-                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                    .setStyle(new NotificationCompat.BigTextStyle())
-                    .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
-                    .setSmallIcon(R.drawable.logo)
-                    .setContentIntent(PendingIntent.getActivity(this, 0, intentAct, flag))
-                    .setAutoCancel(true);
-
-            NotificationManager notificationManager =
-                    (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                NotificationChannel channel = new NotificationChannel("notification_channel002",
-                        "Notification FCM",
-                        NotificationManager.IMPORTANCE_LOW);
-                notificationManager.createNotificationChannel(channel);
-            }
-
-            notificationManager.notify(0, notificationBuilder.build());
+            title = remoteMessage.getNotification().getTitle();
+            body = remoteMessage.getNotification().getBody();
+        } else if (!remoteMessage.getData().isEmpty()) {
+            title = remoteMessage.getData().get("title");
+            body = remoteMessage.getData().get("body");
         }
+
+        if (title != null || body != null) {
+            sendNotification(title, body);
+        }
+    }
+
+    private void sendNotification(String title, String message) {
+        Intent intentAct = new Intent(this, SplashActivity.class);
+        intentAct.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        int flag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0;
+
+        String channelId = "notification_channel002";
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, channelId)
+                .setContentTitle(title)
+                .setContentText(message)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setStyle(new NotificationCompat.BigTextStyle())
+                .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
+                .setSmallIcon(R.drawable.logo)
+                .setContentIntent(PendingIntent.getActivity(this, 0, intentAct, flag))
+                .setAutoCancel(true);
+
+        NotificationManager notificationManager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(channelId,
+                    "Notification FCM",
+                    NotificationManager.IMPORTANCE_LOW);
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        notificationManager.notify(0, notificationBuilder.build());
     }
 
 }

--- a/app/src/main/java/com/kyata/pdfreader/utils/FileUtils.java
+++ b/app/src/main/java/com/kyata/pdfreader/utils/FileUtils.java
@@ -43,7 +43,8 @@ public class FileUtils {
                     return Environment.getExternalStorageDirectory() + "/" + split[1];
                 }
 
-                // TODO handle non-primary volumes
+                // handle non-primary volumes
+                return "/storage/" + type + "/" + split[1];
             }
             // DownloadsProvider
             else if (isDownloadsDocument(uri)) {

--- a/app/src/main/java/com/kyata/pdfreader/utils/PathUtil.java
+++ b/app/src/main/java/com/kyata/pdfreader/utils/PathUtil.java
@@ -17,6 +17,7 @@ import android.webkit.MimeTypeMap;
 
 
 import com.kyata.pdfreader.App;
+import com.kyata.pdfreader.R;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -96,7 +97,8 @@ public class PathUtil {
                     return Environment.getExternalStorageDirectory() + "/" + split[1];
                 }
 
-                // TODO handle non-primary volumes
+                // handle non-primary volumes
+                return "/storage/" + type + "/" + split[1];
             }
             // DownloadsProvider
             else if (isDownloadsDocument(uri)) {
@@ -236,11 +238,13 @@ public class PathUtil {
 
 
     public static int getFileIcon(boolean isDir, String filePath) {
-        if (!TextUtils.isEmpty(filePath)) {
-            return getFileIcon(isDir, filePath);
-        } else {
-            return 0;
+        if (isDir) {
+            return R.drawable.ic_folder;
         }
+        if (!TextUtils.isEmpty(filePath) && filePath.toLowerCase().endsWith(".pdf")) {
+            return R.drawable.ic_item_pdf;
+        }
+        return R.drawable.ic_item_file;
     }
 
     private static boolean isCompareFiles(String path1, String path2) {


### PR DESCRIPTION
## Summary
- support non-primary volumes in FileUtils and PathUtil
- avoid recursion in PathUtil.getFileIcon
- show FCM notifications via helper method

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68441847a37c83288fb81be207e21c51